### PR TITLE
Redesign homepage calendar with modern responsive layout

### DIFF
--- a/WebScheduler/src/app/scheduler/home/home.component.css
+++ b/WebScheduler/src/app/scheduler/home/home.component.css
@@ -1,48 +1,286 @@
-.box {
-    float: left;
-    height: 20px;
-    width: 20px;
-    margin-bottom: 15px;
-    border: 1px solid black;
-    clear: both;
+/* ── Layout ── */
+.calendar-layout {
+  display: flex;
+  gap: 2rem;
+  padding: 2rem;
+  max-width: 1400px;
+  margin: 0 auto;
+}
+
+/* ── Sidebar ── */
+.calendar-sidebar {
+  flex: 0 0 220px;
+  display: flex;
+  flex-direction: column;
+  padding-top: 0.5rem;
+}
+
+.sidebar-month-name {
+  font-size: 1.75rem;
+  font-weight: 700;
+  color: #1a1a2e;
+  line-height: 1.2;
+}
+
+.sidebar-year {
+  font-size: 1.1rem;
+  font-weight: 500;
+  color: #6c757d;
+  margin-bottom: 1.25rem;
+}
+
+.sidebar-nav {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 2rem;
+}
+
+.nav-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: #f0f2f5;
+  border: none;
+  border-radius: 8px;
+  padding: 0.4rem 0.75rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #1a1a2e;
+  cursor: pointer;
+  transition: background 0.15s, transform 0.1s;
+}
+
+.nav-btn:hover {
+  background: #e2e6ea;
+  transform: translateY(-1px);
+}
+
+.nav-btn:active {
+  transform: translateY(0);
+}
+
+/* ── Legend ── */
+.sidebar-legend {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.legend-title {
+  font-size: 0.8rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: #6c757d;
+  margin-bottom: 0.25rem;
+}
+
+.legend-item {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.875rem;
+}
+
+.legend-color {
+  width: 14px;
+  height: 14px;
+  border-radius: 4px;
+  flex-shrink: 0;
+}
+
+.legend-text {
+  flex: 1;
+  color: #1a1a2e;
+  font-weight: 500;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.legend-hours {
+  color: #6c757d;
+  font-size: 0.8rem;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+
+/* ── Calendar grid ── */
+.calendar-main {
+  flex: 1;
+  min-width: 0;
+  overflow-x: auto;
+}
+
+.calendar-grid {
+  width: 100%;
+  border-collapse: separate;
+  border-spacing: 4px;
+  table-layout: fixed;
+}
+
+.calendar-grid thead th {
+  text-align: center;
+  padding: 0.5rem 0.25rem;
+  font-size: 0.8rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: #6c757d;
+}
+
+.day-full {
+  display: inline;
+}
+
+.day-short {
+  display: none;
+}
+
+.calendar-grid tbody td {
+  vertical-align: top;
+  padding: 0;
+  height: 90px;
+}
+
+.empty-cell {
+  background: transparent !important;
+}
+
+.day-cell {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  height: 100%;
+  padding: 0.5rem;
+  border-radius: 10px;
+  background: #f8f9fa;
+  transition: transform 0.12s, box-shadow 0.12s;
+  cursor: default;
+}
+
+.day-cell:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+}
+
+.day-cell.has-duty {
+  color: #fff;
+}
+
+.day-cell.has-duty .day-number,
+.day-cell.has-duty .day-hours {
+  color: #fff;
+}
+
+.day-number {
+  font-size: 0.95rem;
+  font-weight: 700;
+  color: #1a1a2e;
+}
+
+.day-hours {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #495057;
+  align-self: flex-end;
+}
+
+.day-cell.holiday .day-number {
+  color: #dc3545;
+}
+
+.day-cell.holiday.has-duty .day-number {
+  color: #ffb3b8;
+}
+
+/* ── Responsive ── */
+@media (max-width: 1024px) {
+  .calendar-layout {
+    flex-direction: column;
+    padding: 1rem;
+    gap: 1.25rem;
   }
 
-.font-red {
-  color: red;
+  .calendar-sidebar {
+    flex: none;
+    flex-direction: row;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.75rem;
+  }
+
+  .sidebar-month-name {
+    font-size: 1.35rem;
+  }
+
+  .sidebar-year {
+    margin-bottom: 0;
+    margin-right: auto;
+  }
+
+  .sidebar-nav {
+    margin-bottom: 0;
+  }
+
+  .sidebar-legend {
+    flex-direction: row;
+    flex-wrap: wrap;
+    gap: 0.5rem 1rem;
+    width: 100%;
+    padding-top: 0.5rem;
+    border-top: 1px solid #e9ecef;
+  }
+
+  .legend-title {
+    width: 100%;
+    margin-bottom: 0;
+  }
 }
 
+@media (max-width: 768px) {
+  .day-full {
+    display: none;
+  }
 
-.calendar-table {
-  border: 1px solid #dddddd;
+  .day-short {
+    display: inline;
+  }
+
+  .calendar-grid tbody td {
+    height: 70px;
+  }
+
+  .day-cell {
+    padding: 0.35rem;
+    border-radius: 8px;
+  }
+
+  .day-number {
+    font-size: 0.8rem;
+  }
+
+  .day-hours {
+    font-size: 0.75rem;
+  }
 }
 
-.pick-calendar th {
-  min-width: 110px;
-  height: 80px;
-  vertical-align: bottom;
-  text-align: center;
-}
+@media (max-width: 480px) {
+  .calendar-layout {
+    padding: 0.5rem;
+  }
 
-.pick-calendar td {
-  min-width: 120px;
-  height: 110px;    
-}
+  .calendar-grid {
+    border-spacing: 2px;
+  }
 
-.calendar-save-margin {
-  margin-top: 85px;
-}
+  .calendar-grid tbody td {
+    height: 55px;
+  }
 
-.cell-button {
-  width: 100%;
-  height: 100%;
-  border: 0;
-}
-
-.date-font {
-  font-size: 14px;
-  font-weight: 700;
-}
-
-.hours-font {
-  font-size: 18px;
+  .day-cell {
+    padding: 0.25rem;
+    border-radius: 6px;
+  }
 }

--- a/WebScheduler/src/app/scheduler/home/home.component.html
+++ b/WebScheduler/src/app/scheduler/home/home.component.html
@@ -1,83 +1,70 @@
-<div class="container">
+<div class="calendar-layout">
 
-  <div class="row d-flex justify-content-center mt-4">
-    <h4>Raspored dežurstva</h4>
+  <div class="calendar-sidebar">
+    <div class="sidebar-month-name">
+      {{ monthNames[selectedMonth.getMonth()] }}
+    </div>
+    <div class="sidebar-year">
+      {{ selectedMonth.getFullYear() }}
+    </div>
+
+    <div class="sidebar-nav">
+      <button class="nav-btn" (click)="prevMonth()" title="Prethodni mjesec">
+        <svg width="20" height="20" viewBox="0 0 20 20" fill="none">
+          <path d="M12.5 15L7.5 10L12.5 5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+        </svg>
+      </button>
+      <button class="nav-btn" (click)="today()" title="Trenutni mjesec">Danas</button>
+      <button class="nav-btn" (click)="nextMonthNav()" title="Sljedeći mjesec">
+        <svg width="20" height="20" viewBox="0 0 20 20" fill="none">
+          <path d="M7.5 15L12.5 10L7.5 5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+        </svg>
+      </button>
+    </div>
+
+    <div class="sidebar-legend">
+      <div class="legend-title">Raspored</div>
+      @for (user of Usernames; track user) {
+        <div class="legend-item">
+          <span class="legend-color" [style.background-color]="UserColors.get(user)"></span>
+          <span class="legend-text">{{ user }}</span>
+          <span class="legend-hours">{{ UserHours.get(user) }}h</span>
+        </div>
+      }
+    </div>
   </div>
-  <div class="row">
-    <div class="col-10">
 
-      <div class="pick-calendar">
-        <table class="calndar-table">
-          <tbody>
-            <tr>
-              @for (i of [0,1,2,3,4,5,6]; track i) {
-                <th>{{dayNames[i]}}</th>
-              }
-            </tr>
-            @for (weeks of MonthWeeks; track weeks) {
-              <tr>
-                @for (days of weeks; track days) {
-                  <td>
-                    @if (!days.hidden) {
-                      <button type="button" class="cell-button" [title]="days.user" [style.background-color]="days.color" [ngClass]="{'font-red' : days.holyday}">
-                        <p class="w-100">
-                          <label class="ml-5 pl-3 date-font">
-                            {{days.date | date: 'dd'}}
-                          </label>
-                          <br />
-                          <label class="hours-font mt-3">
-                            {{days.hours}} h
-                          </label>
-                        </p>
-                      </button>
+  <div class="calendar-main">
+    <table class="calendar-grid">
+      <thead>
+        <tr>
+          @for (i of [0,1,2,3,4,5,6]; track i) {
+            <th>
+              <span class="day-full">{{ dayNames[i] }}</span>
+              <span class="day-short">{{ dayNamesShort[i] }}</span>
+            </th>
+          }
+        </tr>
+      </thead>
+      <tbody>
+        @for (weeks of MonthWeeks; track weeks) {
+          <tr>
+            @for (days of weeks; track days) {
+              <td [class.empty-cell]="days.hidden">
+                @if (!days.hidden) {
+                  <div class="day-cell" [style.background-color]="days.color || null" [class.holiday]="days.holyday" [class.has-duty]="days.user" [title]="days.user">
+                    <span class="day-number">{{ days.date | date: 'dd' }}</span>
+                    @if (days.hours) {
+                      <span class="day-hours">{{ days.hours }}h</span>
                     }
-                  </td>
+                  </div>
                 }
-              </tr>
+              </td>
             }
-          </tbody>
-        </table>
-      </div>
-
-    </div>
-    <div class="col-2 mt-5">
-
-      <form [formGroup]="form" (ngSubmit)="getDataForMonth()">
-
-        <div class="row">
-
-          <div class="form-group w-100">
-            <label for="month">Mjesec:</label>
-            <select formControlName="month" class="form-control">
-              @for (mon of monthList; track mon) {
-                <option [value]="mon.value">{{mon.viewValue}}</option>
-              }
-            </select>
-            @if (form.get('month')?.touched && form.get('month')?.invalid) {
-              <div class="alert alert-danger">
-                @if (form.get('month')?.errors) {
-                  <div>Mjesec je obavezan za odabir.</div>
-                }
-              </div>
-            }
-          </div>
-        </div>
-        <div class="row">
-          <button class="btn btn-primary w-100" type="submit" [disabled]="!form.valid">Dohvati</button>
-        </div>
-
-      </form>
-
-      <div class="row mt-5">
-        @for (user of Usernames; track user) {
-          <div>
-            <div class="box mr-2" [style.background-color]="UserColors.get(user)"></div> {{user}} - {{UserHours.get(user)}} sati
-          </div>
+          </tr>
         }
-      </div>
-
-    </div>
+      </tbody>
+    </table>
   </div>
-
 
 </div>

--- a/WebScheduler/src/app/scheduler/home/home.component.ts
+++ b/WebScheduler/src/app/scheduler/home/home.component.ts
@@ -1,7 +1,6 @@
 import { DatePipe } from '@angular/common';
 import { HttpClient } from '@angular/common/http';
 import { Component, OnInit } from '@angular/core';
-import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { ISchedule } from 'src/app/_models/Schedule';
 import { ColorService } from 'src/app/_services/color.service';
 import { TokenStorageService } from 'src/app/_services/token-storage.service';
@@ -24,21 +23,15 @@ export class HomeComponent implements OnInit {
   content?: string;
 
   dayNames: string[] = ['Ponedjeljak', 'Utorak', 'Srijeda', 'Četvrtak', 'Petak', 'Subota', 'Nedjelja'];
+  dayNamesShort: string[] = ['Pon', 'Uto', 'Sri', 'Čet', 'Pet', 'Sub', 'Ned'];
   monthNames: string[] = ['Siječanj', 'Veljača', 'Ožujak', 'Travanj', 'Svibanj', 'Lipanj', 'Srpanj', 'Kolovoz', 'Rujan', 'Listopad', 'Studeni', 'Prosinac'];
 
-  thisMonth = new Date(new Date().setMonth(new Date().getMonth(), 1));
-  nextMonth = new Date(new Date().setMonth(new Date().getMonth() + 1, 1));
-  selectedMonth = this.thisMonth;
-  monthList: SelectedMonth[] = [];
-
-  form: FormGroup = this.fb.group({
-    month: [new Date(), Validators.required]
-  });
+  selectedMonth = new Date(new Date().getFullYear(), new Date().getMonth(), 1);
 
   schedule: ISchedule = {
     id: 0,
     valid: false,
-    month: this.nextMonth,
+    month: new Date(),
     generatedDateTime: new Date(),
     generatedByUser: "",
     userDuties: []
@@ -51,36 +44,35 @@ export class HomeComponent implements OnInit {
   UserColors = new Map<string, string>();
   UserHours = new Map<string, number>();
 
-  constructor(private tokenStorageService: TokenStorageService, private http: HttpClient, private datePipe: DatePipe, private fb: FormBuilder, private colorService: ColorService) { }
+  constructor(private tokenStorageService: TokenStorageService, private http: HttpClient, private datePipe: DatePipe, private colorService: ColorService) { }
 
   ngOnInit(): void {
-    
-    for (let i = 1; i >= -10; i--) {
-        this.monthList.push({value: new Date(new Date().setMonth(new Date().getMonth() + i, 1)), viewValue: this.monthNames[new Date(new Date().setMonth(new Date().getMonth() + i, 1)).getMonth()] + " " + this.datePipe.transform(new Date(new Date().setMonth(new Date().getMonth() + i, 1)), 'yyyy') } );
-      }
-      
-    this.form.patchValue({month: this.thisMonth});
-
-    this.getDataForMonth();
+    this.loadMonth();
   }
 
-  getDataForMonth(){  
-    this.selectedMonth = this.form.value.month;
+  prevMonth(): void {
+    this.selectedMonth = new Date(this.selectedMonth.getFullYear(), this.selectedMonth.getMonth() - 1, 1);
+    this.loadMonth();
+  }
 
-    let year = this.datePipe.transform(this.selectedMonth, 'yyyy'); 
-    let month = this.datePipe.transform(this.selectedMonth, 'MM'); 
+  nextMonthNav(): void {
+    this.selectedMonth = new Date(this.selectedMonth.getFullYear(), this.selectedMonth.getMonth() + 1, 1);
+    this.loadMonth();
+  }
 
-    this.selectedMonth = new Date(Number(year), Number(month) - 1, 1);
+  today(): void {
+    this.selectedMonth = new Date(new Date().getFullYear(), new Date().getMonth(), 1);
+    this.loadMonth();
+  }
 
-    //console.log(this.selectedMonth.getDay());
-    
-    let requestedMonth = this.datePipe.transform(this.selectedMonth, 'yyyy-MM-dd'); 
+  loadMonth(): void {
+    let requestedMonth = this.datePipe.transform(this.selectedMonth, 'yyyy-MM-dd');
 
     var numOfDays = this.getNumberOfDaysInMonth(this.selectedMonth.getMonth(), this.selectedMonth.getFullYear());
     var dayofweekfirstday = this.selectedMonth.getDay();
     if(dayofweekfirstday == 0) dayofweekfirstday = 7;
 
-    var week = [];
+    var week: any[] = [];
     var currentDay = 1;
     this.MonthWeeks = [];
 
@@ -97,8 +89,7 @@ export class HomeComponent implements OnInit {
     }
 
     for (let i = 1; i <= numOfDays; i++) {
-      if(currentDay > 7)
-      {
+      if(currentDay > 7) {
         this.MonthWeeks.push(week);
         week = [];
         currentDay = 1;
@@ -112,11 +103,10 @@ export class HomeComponent implements OnInit {
         user: '',
         holyday: false,
         hours: 0
-      });       
+      });
     }
 
-    if(currentDay > 1)
-    {
+    if(currentDay > 1) {
       for (let i = currentDay; i <= 7; i++) {
         week.push({
           dayNo: currentDay++,
@@ -150,26 +140,25 @@ export class HomeComponent implements OnInit {
                       this.UserColors.set(username, this.colorService.getNextColor());
                       this.UserHours.set(username, 0);
                     });
-                 
+
                     this.MonthWeeks.forEach( (value) => {
                       value.forEach( (dayinweek: { dayNo: number; hidden: boolean; date: any; color: string | undefined; user: string; holyday: boolean; hours: number;}) => {
-                        
+
                         var duty = this.schedule.userDuties.find(duty => duty.day == dayinweek.date);
-                        if(duty != undefined) 
-                        {                        
+                        if(duty != undefined) {
                           dayinweek.user = duty.username;
                           dayinweek.color = this.UserColors.get(duty.username);
                           dayinweek.hours = duty.hours;
 
-                          this.UserHours.set(duty.username, this.UserHours.get(duty.username) + duty.hours); 
+                          this.UserHours.set(duty.username, (this.UserHours.get(duty.username) || 0) + duty.hours);
                         }
 
                       });
-                    }); 
+                    });
 
                   },
                   error: err => {
-                    
+
                   }
                 });
 
@@ -177,20 +166,17 @@ export class HomeComponent implements OnInit {
                 .subscribe({
                    next: data => {
 
-                     this.Holydays = JSON.parse(data).map((item: { day: Date; }) => item.day);;  
-
-                     //console.log(this.Holydays);
+                     this.Holydays = JSON.parse(data).map((item: { day: Date; }) => item.day);
 
                      this.MonthWeeks.forEach( (value) => {
                       value.forEach( (dayinweek: { dayNo: number; hidden: boolean; date: any; color: string | undefined; user: string; holyday: boolean; hours: number; }) => {
 
-                        if(this.Holydays.includes(dayinweek.date) || dayinweek.dayNo >= 6) 
-                        {                        
+                        if(this.Holydays.includes(dayinweek.date) || dayinweek.dayNo >= 6) {
                           dayinweek.holyday = true;
                         }
 
                       });
-                    }); 
+                    });
                    },
                    error: err => {
                      this.Holydays = [];
@@ -199,7 +185,6 @@ export class HomeComponent implements OnInit {
   }
 
   getNumberOfDaysInMonth(month: number, year: number) : number {
-
     var selectedmonth = new Date(year, month, 1);
     var nextMonth = new Date(selectedmonth.setMonth(selectedmonth.getMonth() + 1, 1));
     return new Date(nextMonth.getFullYear(), nextMonth.getMonth(), 0).getDate();


### PR DESCRIPTION
Replaced old table-based calendar + dropdown month selector with a modern flexbox layout
Month name, year, prev/next/today navigation buttons and user legend are now in a sidebar to the left — nothing sits above the calendar grid
Day cells have rounded corners, hover effects, and clean typography with color-coded duty assignments
3 responsive breakpoints (1024px, 768px, 480px) — sidebar wraps above on smaller screens, day names abbreviate on mobile